### PR TITLE
ASM-17961: mirror strict security hardening in docker-compose POC stack.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,11 @@ services:
     image: akeyless/base:latest-akeyless
     container_name: 'akeyless-gateway'
     restart: always
+    user: "1001:1001"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     ports:
       - "8000:8000"
       - "8080:8080"
@@ -45,6 +50,8 @@ services:
       - gateway.env
       - cache.env
     platform: linux/amd64
+    mem_limit: 4g
+    cpus: "2"
     links:
       - "akeyless-cache"
     # volumes:
@@ -89,6 +96,13 @@ services:
     image: akeyless/zero-trust-bastion:latest
     container_name: 'akeyless-sra-web'
     restart: always
+    user: "1001:1001"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    mem_limit: 4g
+    cpus: "2"
     ports:
       - "8888:8888"
     env_file:
@@ -113,7 +127,20 @@ services:
       akeyless-gateway:
         condition: service_healthy
     image: akeyless/zero-trust-bastion:latest
-    privileged: true 
+    # Phase A hardening: narrow capabilities (no privileged)
+    # Still runs as root - documented exception required for Kyverno
+    # Phase B (separate epic) will refactor to non-root
+    cap_add:
+      - SYS_ADMIN      # Required for mount --bind /dev/pts
+      - MKNOD          # Required for mknod device nodes in jail
+      - DAC_OVERRIDE   # Required for adduser/deluser/jail permissions
+      - CHOWN          # Required by adduser + chroot setup
+      - SETUID         # Required by adduser + chroot setup
+      - SETGID         # Required by adduser + chroot setup
+      - FOWNER         # Required by adduser + chroot setup
+    security_opt:
+      # allowPrivilegeEscalation must be true for mount --bind to work
+      - no-new-privileges:false
     container_name: 'akeyless-sra-ssh'
     restart: always
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -131,6 +131,8 @@ services:
     # Still runs as root - documented exception required for Kyverno
     # Phase B (separate epic) will refactor to non-root
     cap_add:
+      - SYS_CHROOT     # sshd privilege separation: chroot("/run/sshd") [preauth]
+      - AUDIT_WRITE    # sshd session: linux_audit_write_entry after pubkey auth
       - SYS_ADMIN      # Required for mount --bind /dev/pts
       - MKNOD          # Required for mknod device nodes in jail
       - DAC_OVERRIDE   # Required for adduser/deluser/jail permissions


### PR DESCRIPTION
Apply non-root user, cap drops, and resource limits for gateway and web; replace SSH privileged mode with the documented Phase A capability set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened Docker Compose container security by running services as non-root and enabling `no-new-privileges` where applicable.
  * Reduced attack surface by dropping all Linux capabilities for the gateway and web services.
  * Added resource limits (memory and CPU) to improve runtime stability.
  * Hardened the SSH service by removing `privileged` mode and applying capability-based security controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->