### PR TITLE
ASM-18581: drop amd64 platform pins for multi-arch images

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ This folder provides an example Docker Compose setup for running:
 
 Refer to Akeyless docs for full details: https://docs.akeyless.io/docs
 
+## Architecture support
+
+The Akeyless Gateway and SRA (`zero-trust-bastion`) images are published as
+multi-arch manifests (`linux/amd64` and `linux/arm64`). This Compose file sets no
+`platform:` pin, so Docker automatically pulls the image variant matching the
+host — run it unchanged on x86_64 or on arm64 hosts (AWS Graviton, Apple silicon).
+To force a specific variant, set `DOCKER_DEFAULT_PLATFORM=linux/amd64` (or
+`linux/arm64`) in your environment.
+
 ## Prerequisites
 
 ### Intended use & production guidance

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,7 +44,6 @@ services:
     env_file:
       - gateway.env
       - cache.env
-    platform: linux/amd64
     links:
       - "akeyless-cache"
     # volumes:
@@ -98,7 +97,6 @@ services:
     environment:
       REMOTE_ACCESS_TYPE: "web"
       DEBUG: true
-    platform: linux/amd64
     links:
       - "akeyless-cache"
     networks:
@@ -143,7 +141,6 @@ services:
       # Example (relative path):
       # - ./home/ca.pub:/var/akeyless/creds/ca.pub --> Define the relative location of the ca.pub file
       
-    platform: linux/amd64
     links:
       - "akeyless-cache"
     networks:


### PR DESCRIPTION
## Summary
Part of [ASM-18581](https://akeyless.atlassian.net/browse/ASM-18581) (SRA ARM64). The Gateway and SRA (`zero-trust-bastion`) images now publish multi-arch manifests, so the `platform: linux/amd64` pins are no longer needed — and they *prevented* the stack from running natively on arm64 hosts.

- Removed the three `platform: linux/amd64` pins (gateway, sra-web, sra-ssh). Docker now auto-selects the host-matching variant.
- README: new "Architecture support" note (multi-arch behavior + `DOCKER_DEFAULT_PLATFORM` override).

Now runs unchanged on x86_64 **and** arm64 (AWS Graviton, Apple silicon).

## Depends on
The multi-arch images being published — `zero-trust-bastion` via the ASM-18581 stack (akeylesslabs/zero-trust-bastion #383/#387/#388); the Gateway image is already multi-arch.

## Test plan
- [x] YAML valid; all services intact; no `platform:` pins remain
- [ ] `docker compose --profile sra up` on an arm64 host pulls arm64 variants (post image publish)
- [ ] amd64 host unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ASM-18581]: https://akeyless.atlassian.net/browse/ASM-18581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for multi-architecture Docker image support.
  * Clarified how Docker automatically selects the matching image variant for supported platforms.
  * Explained how to override the default platform when needed.

* **Bug Fixes**
  * Removed fixed platform settings from container setup so images can run with the appropriate architecture automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->